### PR TITLE
Add task polling env-var

### DIFF
--- a/helm/values/apps/paperless-ngx.yaml
+++ b/helm/values/apps/paperless-ngx.yaml
@@ -15,6 +15,8 @@ paperlessngx:
       value: "ara"
     - name: PAPERLESS_FILENAME_FORMAT
       value: "{{ correspondent }}/{{ created_year }}-{{ created_month }}-{{ title }}"
+    - name: PAPERLESS_CONSUMER_POLLING
+      value: "30"
 
 adminSecret:
   enabled: true


### PR DESCRIPTION
This PR adds an explicity setting for Paperless-Ngx polling configuration to 30 seconds. This resolves documents being not processed from the `consume/` directory.

Resources:
https://docs.paperless-ngx.com/configuration/#PAPERLESS_CONSUMER_POLLING

https://github.com/paperless-ngx/paperless-ngx/discussions/3713