### PR TITLE
Delegate chart enable control to parent charts

### DIFF
--- a/helm/charts/nfspersistence/Chart.yaml
+++ b/helm/charts/nfspersistence/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nfspersistence
 description: A generic Helm chart for deploying NFS based persistence storage.
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "1.0"
 
 # maintainers:

--- a/helm/charts/nfspersistence/templates/pv.yaml
+++ b/helm/charts/nfspersistence/templates/pv.yaml
@@ -1,6 +1,6 @@
 # This will not be rendered if a storageClassName is provided in values.yaml
 # Which means the PV will be created dynamically by the NFS client provisioner
-{{- if .Values.persistence.enabled }}
+{{- if .Values.enabled }}
 {{- if not .Values.persistence.storageClassName }}
 apiVersion: v1
 kind: PersistentVolume

--- a/helm/charts/nfspersistence/templates/pvc.yaml
+++ b/helm/charts/nfspersistence/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.enabled }}
+{{- if .Values.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/helm/charts/nfspersistence/values.yaml
+++ b/helm/charts/nfspersistence/values.yaml
@@ -1,4 +1,9 @@
 ---
+# Whether to enable this chart. The reason of this is to allow
+# stateless-apps chart that deploys releases *without* storage
+# to disable this chart.
+enabled: true
+
 labels:
   app: ""
 annotations:
@@ -6,7 +11,6 @@ annotations:
   custom.synology/path-hint: ""
 
 persistence:
-  enabled: true
   name: "persistence-foo"
   size: 1Gi
   accessMode: ReadWriteMany


### PR DESCRIPTION
This PR allow parent charts that deploys releases with or without storage to enable/disable the nfs subchart while keeping it in the dependency list.