### PR TITLE
Disable K3s build in LB

### DIFF
--- a/ansible/inventory/prod/k3s.yml
+++ b/ansible/inventory/prod/k3s.yml
@@ -29,6 +29,8 @@ k3s_cluster:
 
     # Optional vars
     # extra_server_args: "--disable=traefik"
+    # Shakir: Disable this if you're using MetalLB
+    extra_server_args: "--disable=servicelb"
     # extra_agent_args: ""
     # extra_install_envs: { 'INSTALL_K3S_SKIP_SELINUX_RPM': 'true' }
     # cluster_context: k3s-ansible


### PR DESCRIPTION
Resolves both LBs MetalLB and Service-LB Controller fighting over the same LoadBalancer services.